### PR TITLE
Fix GitHub execution issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Recommended basic configuration:
 ```yaml
 name: No Response
 
-# Both `issue_comment` and `scheduled` event types are required for this Action
+# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
 # to work properly.
 on:
+  issues:
+    types: [closed]
   issue_comment:
     types: [created]
   schedule:
@@ -25,7 +27,7 @@ jobs:
   noResponse:
     runs-on: ubuntu-latest
     steps:
-      - uses: MBilalShafi/no-response@v0.0.4
+      - uses: MBilalShafi/no-response@v0.0.6
         with:
           token: ${{ github.token }}
 ```
@@ -50,7 +52,7 @@ jobs:
   noResponse:
     runs-on: ubuntu-latest
     steps:
-      - uses: MBilalShafi/no-response@v0.0.4
+      - uses: MBilalShafi/no-response@v0.0.6
         with:
           token: ${{ github.token }}
           # auto close issues with no response from author for 7 days

--- a/dist/index.js
+++ b/dist/index.js
@@ -13270,6 +13270,7 @@ function run() {
             const eventName = process.env['GITHUB_EVENT_NAME'];
             const config = new config_1.default();
             const noResponse = new no_response_1.default(config);
+            console.log(eventName, 'eventName');
             if (eventName === 'schedule') {
                 noResponse.sweep();
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -13270,7 +13270,6 @@ function run() {
             const eventName = process.env['GITHUB_EVENT_NAME'];
             const config = new config_1.default();
             const noResponse = new no_response_1.default(config);
-            console.log(eventName, 'eventName');
             if (eventName === 'schedule') {
                 noResponse.sweep();
             }
@@ -13356,7 +13355,7 @@ class NoResponse {
     removeLabels() {
         return __awaiter(this, void 0, void 0, function* () {
             core.debug('Starting removeLabels');
-            const { optionalFollowUpLabel } = this.config;
+            const { optionalFollowUpLabel, responseRequiredLabel } = this.config;
             if (!optionalFollowUpLabel) {
                 return;
             }
@@ -13371,7 +13370,16 @@ class NoResponse {
             // if the issue closed by the issue author, check if optionalFollowUpLabel is present on the issue and then remove it
             if (payload.action === 'closed' && payload.issue.user.login === payload.sender.login) {
                 const labels = yield this.octokit.rest.issues.listLabelsOnIssue(issue);
-                if (labels.data.map((label) => label.name).includes(optionalFollowUpLabel)) {
+                const plainLabels = labels.data.map((label) => label.name);
+                if (plainLabels.includes(responseRequiredLabel)) {
+                    yield this.octokit.rest.issues.removeLabel({
+                        owner,
+                        repo,
+                        issue_number: number,
+                        name: responseRequiredLabel
+                    });
+                }
+                if (plainLabels.includes(optionalFollowUpLabel)) {
                     yield this.octokit.rest.issues.removeLabel({
                         owner,
                         repo,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "no-response-add-label",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "description": "A GitHub Action that closes Issues where the author hasn't responded to a request for more information",
   "main": "dist/index.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ async function run(): Promise<void> {
 
     const config = new Config()
     const noResponse = new NoResponse(config)
+    console.log(eventName, 'eventName')
 
     if (eventName === 'schedule') {
       noResponse.sweep()

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,6 @@ async function run(): Promise<void> {
 
     const config = new Config()
     const noResponse = new NoResponse(config)
-    console.log(eventName, 'eventName')
-
     if (eventName === 'schedule') {
       noResponse.sweep()
     } else if (eventName === 'issue_comment') {

--- a/src/no-response.ts
+++ b/src/no-response.ts
@@ -58,7 +58,7 @@ export default class NoResponse {
   async removeLabels(): Promise<void> {
     core.debug('Starting removeLabels')
 
-    const { optionalFollowUpLabel } = this.config
+    const { optionalFollowUpLabel, responseRequiredLabel } = this.config
     if (!optionalFollowUpLabel) {
       return
     }
@@ -74,8 +74,18 @@ export default class NoResponse {
     // if the issue closed by the issue author, check if optionalFollowUpLabel is present on the issue and then remove it
     if (payload.action === 'closed' && payload.issue.user.login === payload.sender.login) {
       const labels = await this.octokit.rest.issues.listLabelsOnIssue(issue)
+      const plainLabels = labels.data.map((label: any) => label.name)
 
-      if (labels.data.map((label: any) => label.name).includes(optionalFollowUpLabel)) {
+      if (plainLabels.includes(responseRequiredLabel)) {
+        await this.octokit.rest.issues.removeLabel({
+          owner,
+          repo,
+          issue_number: number,
+          name: responseRequiredLabel
+        })
+      }
+
+      if (plainLabels.includes(optionalFollowUpLabel)) {
         await this.octokit.rest.issues.removeLabel({
           owner,
           repo,


### PR DESCRIPTION
The previous [change](https://github.com/MBilalShafi/no-response-add-label/pull/1) didn't work when the `responseRequiredLabel` is already added to the issue because for Close with comment, the execution order for the workflow is:
1. Close
2. Comment

Because comment is done after close, it adds the `optionalFollowupLabel` so it is not properly removed.
To fix it, I configured close event to also remove the `responseRequiredLabel`