### PR TITLE
Add `state_reason` to the closed issues

### DIFF
--- a/src/no-response.ts
+++ b/src/no-response.ts
@@ -148,7 +148,7 @@ export default class NoResponse {
       await this.octokit.rest.issues.createComment({ body: closeComment, ...issue })
     }
 
-    await this.octokit.rest.issues.update({ state: 'closed', ...issue })
+    await this.octokit.rest.issues.update({ state: 'closed', state_reason: 'inactivity', ...issue })
   }
 
   async ensureLabelExists(name: string, color: string): Promise<void> {


### PR DESCRIPTION
As mentioned in https://github.com/mui/mui-x/pull/11805#issuecomment-1933637722 `state_reason: 'inactivity'` could help check another action why exactly the issue was closed and act accordingly.