### PR TITLE
add back @lee-dohm copyright line in license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright &copy; 2021 [Lee Dohm](https://www.lee-dohm.com)
 Copyright &copy; 2023 [Bilal Shafi](https://BilalShafi.dev)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
This PR adds back the copyright line from the forked repo to more closely match the spirt & letter of the MIT license.